### PR TITLE
Force iOS 9.3 for the iPhone 4S simulator

### DIFF
--- a/SimulatorController/SimulatorController.swift
+++ b/SimulatorController/SimulatorController.swift
@@ -18,6 +18,9 @@ enum Simulator: String
     case iPhone6Plus = "iPhone 6 Plus"
     case iPhone6s = "iPhone 6s"
     case iPhone6sPlus = "iPhone 6s Plus"
+    case iPhoneSE = "iPhone SE"
+    case iPhone7 = "iPhone 7"
+    case iPhone7Plus = "iPhone 7 Plus"
     case iPad2 = "iPad 2"
     case iPadAir = "iPad Air"
     case iPadAir2 = "iPad Air 2"
@@ -41,6 +44,9 @@ class SimulatorController
         .iPhone6Plus,
         .iPhone6s,
         .iPhone6sPlus,
+        .iPhoneSE,
+        .iPhone7,
+        .iPhone7Plus,
         .iPad2,
         .iPadAir,
         .iPadAir2,
@@ -56,6 +62,9 @@ class SimulatorController
         .iPhone6Plus: FBSimulatorConfiguration.iPhone6Plus(),
         .iPhone6s: FBSimulatorConfiguration.iPhone6s(),
         .iPhone6sPlus: FBSimulatorConfiguration.iPhone6sPlus(),
+        .iPhoneSE: FBSimulatorConfiguration.iPhoneSE(),
+        .iPhone7: FBSimulatorConfiguration.iPhone7(),
+        .iPhone7Plus: FBSimulatorConfiguration.iPhone7Plus(),
         .iPad2: FBSimulatorConfiguration.iPad2(),
         .iPadAir: FBSimulatorConfiguration.iPadAir(),
         .iPadAir2: FBSimulatorConfiguration.iPadAir2(),

--- a/SimulatorController/SimulatorController.swift
+++ b/SimulatorController/SimulatorController.swift
@@ -55,7 +55,7 @@ class SimulatorController
     ]
     
     private static let simulatorMap: [Simulator: FBSimulatorConfiguration] = [
-        .iPhone4s: FBSimulatorConfiguration.iPhone4s(),
+        .iPhone4s: FBSimulatorConfiguration.iPhone4s().iOS_9_3(),
         .iPhone5: FBSimulatorConfiguration.iPhone5(),
         .iPhone5s: FBSimulatorConfiguration.iPhone5s(),
         .iPhone6: FBSimulatorConfiguration.iPhone6(),


### PR DESCRIPTION
Force iOS 9.3 simulator for the iPhone 4S as iOS 9.3.5 it’s the last supported OS version for that device